### PR TITLE
Cmake requires armadillo library

### DIFF
--- a/gr-bfutils/CMakeLists.txt
+++ b/gr-bfutils/CMakeLists.txt
@@ -91,7 +91,7 @@ include(GrVersion)
 
 include(GrPlatform) #define LIB_SUFFIX
 
-find_package(Armadillo)
+find_package(Armadillo REQUIRED)
 find_package(GSL)
 
 if(NOT CMAKE_MODULES_DIR)


### PR DESCRIPTION
gr-bfutils requires armadillo library (sudo make install libarmadillo-dev)
Cmake now requires armadillo.